### PR TITLE
Task 4 - Total kills and kills register

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -20,6 +20,7 @@ class Parser
   def initialize(path)
     raise 'File not found' unless File.exist?(path)
 
+    @players = []
     @path = path
   end
 
@@ -32,11 +33,12 @@ class Parser
 
   def generate_json
     file = @path.split('/').last
+    list_players
 
     obj = {
       file => {
         lines: count_lines,
-        players: count_players
+        players: @players
       }
     }
 
@@ -49,28 +51,23 @@ class Parser
     File.readlines(@path).count
   end
 
-  def count_players
-    players = []
-
+  def list_players
     File.readlines(@path).each do |line|
       PATTERNS.each do |pattern|
-        player_name = line_scanner(line, pattern)
-
-        player_include(player_name, players)
+        include_player(find_player(line, pattern))
       end
     end
-
-    players
   end
 
-  def line_scanner(line, pattern)
+  def find_player(line, pattern)
     return unless line.include?(pattern[:word])
 
     line.split(pattern[:init]).last.split(pattern[:end]).first
   end
 
-  def player_include(player_name, players)
+  def include_player(player_name)
     return unless player_name
-    return players << player_name unless players.include?(player_name)
+
+    @players << player_name unless @players.include?(player_name)
   end
 end

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -18,6 +18,8 @@ class Parser
   ].freeze
 
   def initialize(path)
+    raise 'File not found' unless File.exist?(path)
+
     @path = path
   end
 

--- a/main.rb
+++ b/main.rb
@@ -5,4 +5,4 @@ require 'json'
 
 parser = Parser.new('./data/games.log')
 
-puts parser.generate_json
+puts parser.output_json

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -11,7 +11,7 @@ describe Parser do
       subject { described_class.new('./spec/fixtures/some_random_file.log') }
 
       it 'returns an error' do
-        expect { subject.first_line }.to raise_error('File not found')
+        expect { subject.first_line }.to raise_error(RuntimeError, 'File not found')
       end
     end
   end
@@ -24,10 +24,10 @@ describe Parser do
     end
   end
 
-  describe '#generate_json' do
-    subject { described_class.new(path).generate_json }
+  describe '#output_json' do
+    subject { described_class.new(path).output_json }
 
-    let(:obj) do
+    let(:hash) do
       {
         "games_test.log": {
           "lines": 158,
@@ -36,11 +36,18 @@ describe Parser do
             'Dono da Bola',
             'Mocinha',
             'Zeh'
-          ]
+          ],
+          "kills": {
+            "Isgalamido": 4,
+            "Dono da Bola": 0,
+            "Mocinha": 0,
+            "Zeh": 0
+          },
+          "total_kills": 15
         }
       }
     end
 
-    it { is_expected.to eq(JSON.pretty_generate(obj)) }
+    it { is_expected.to eq(JSON.pretty_generate(hash)) }
   end
 end

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -6,21 +6,21 @@ require './spec/spec_helper'
 describe Parser do
   let(:path) { './spec/fixtures/games_test.log' }
 
-  describe '#first_line' do
-    context 'when the file exist' do
-      subject { described_class.new(path) }
-
-      it 'return the first line of the file' do
-        expect(subject.first_line).to eq("  0:00 ------------------------------------------------------------\n")
-      end
-    end
-
+  describe '#initialize' do
     context 'when the file does not exist' do
       subject { described_class.new('./spec/fixtures/some_random_file.log') }
 
       it 'returns an error' do
-        expect { subject.first_line }.to raise_error(Errno::ENOENT)
+        expect { subject.first_line }.to raise_error('File not found')
       end
+    end
+  end
+
+  describe '#first_line' do
+    subject { described_class.new(path) }
+
+    it 'returns the first line of the file' do
+      expect(subject.first_line).to eq("  0:00 ------------------------------------------------------------\n")
     end
   end
 


### PR DESCRIPTION
    The Parser has been refactored and new methods have been created to count the total number of kills and the kill amount of each player. Now a kill score is registered for each player and the log file's total
 of kills is shown.
    
    Modify:
    - #initialize now creates new instance variables to store total_kills and kill_score
    
    - #generate_json is now a private method and returns a hash with log file's information
    
    Create:
    - #output_json replaces #generate_json to output a pretty_generate json
    
    - #process_game_info reads the log file's lines to extract information using other methods
    
    - #register_players registers the name of all players in @players and register a player name with 0 kills assigned in @kill_score if the player hasn't been registered before
    
    - #check_kill_records add += 1 to player's kill score when it scored a kill
    
    - #find_player_name finds a player name within a given line using a provided pattern
    
    Adjust tests to cover kills and total_kills
    
    Modify main.rb to call Parser#output_json